### PR TITLE
Potential fix to dubious ownership errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ In this example, the `wiki` folder will be synced with the wiki repo everytime a
 | `username` | Y | The repo owner's name. Used for pulling and pushing |
 | `access_token` | Y | An access token to use when pushing to the Wiki repo, can be set using `${{ secrets.GITHUB_TOKEN }}` |
 | `wiki_folder` | N | The folder to sync to the Wiki. <br/> <i>Default: `wiki`</i> |
+| `ignore_safe_warnings` | N | Fixes `fatal: detected dubious ownership in repository at '/wiki'` <br/> <i>Default: `false`</i> |
 | `commit_username` | Y | The username to use when pushing to the wiki repo |
 | `commit_email` | Y | The email address to use when pushing to the wiki repo. Our example uses the [annonymous email](https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address) from GitHub |
 | `commit_message` | N | The commit message to use when pushing to the wiki repo <br/><i>Default: `action: wiki sync` |

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Wiki Sync'
+name: 'Wiki Sync (Fork)'
 description: 'Sync a wiki folder with your GitHub Wiki'
 author: 'JoeIzzard'
 branding:

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Wiki Sync (Fork)'
+name: 'Wiki Sync'
 description: 'Sync a wiki folder with your GitHub Wiki'
 author: 'JoeIzzard'
 branding:

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
         description: 'The folder you want to sync the repo with'
         required: false
         default: 'wiki'
+    ignore_safe_warnings:
+        description: 'Fixes `fatal: detected dubious ownership in repository at /wiki`'
+        required: false
+        default: 'false'
     commit_message:
         description: 'A custom commit message to be used'
         required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,10 @@ if [ ! -d "/github/workspace/${INPUT_WIKI_FOLDER}" ]; then
 fi
 cp -a ${INPUT_WIKI_FOLDER}/. /wiki
 
+if [ "${INPUT_IGNORE_SAFE_WARNINGS}" = "true" ]; then
+    git config --global --add safe.directory /wiki
+fi
+
 echo "Git Config..."
 echo "-> User: ${INPUT_COMMIT_USERNAME}"
 echo "-> Email: ${INPUT_COMMIT_EMAIL}"


### PR DESCRIPTION
With hopes that the development of this action is not yet stale, I decided to take up suggested efforts to implement a fix.

Below here is the error:
- https://github.com/csmir/Commands.NET/actions/runs/7801255687/job/21275912306

occurring with implementation:
- https://github.com/csmir/Commands.NET/.github/workflows/wikisync.yml

This is reopened from a previous issue that raised comparison errors